### PR TITLE
SQS Secure Transport

### DIFF
--- a/examples/config/default.yaml
+++ b/examples/config/default.yaml
@@ -6,6 +6,12 @@ awsext:
       sqsOptions:
         region: us-west-2
         # endpoint: http://localhost:9324
+      kmsOptions:
+        region: 'us-west-2'
+        # endpoint: http://localhost:9324
+      encryption:
+        algorithm: 'aes-256-ecb'
+        key: 'KMS key name'
       schema:
         "id" : "#consumer-example-schema"
         properties:

--- a/examples/config/default.yaml
+++ b/examples/config/default.yaml
@@ -10,7 +10,7 @@ awsext:
         region: 'us-east-1'
         # endpoint: http://localhost:9324
       encryption:
-        key: 'alias/picard-sqs'
+        key: 'alias/sqs-example'
       schema:
         "id" : "#consumer-example-schema"
         properties:

--- a/examples/config/default.yaml
+++ b/examples/config/default.yaml
@@ -10,7 +10,6 @@ awsext:
         region: 'us-east-1'
         # endpoint: http://localhost:9324
       encryption:
-        algorithm: 'aes-256-ecb'
         key: 'alias/picard-sqs'
       schema:
         "id" : "#consumer-example-schema"

--- a/examples/config/default.yaml
+++ b/examples/config/default.yaml
@@ -4,14 +4,14 @@ awsext:
       queue:
         prefix: 'sqs-consumer-example-'
       sqsOptions:
-        region: us-west-2
+        region: 'us-west-2'
         # endpoint: http://localhost:9324
       kmsOptions:
-        region: 'us-west-2'
+        region: 'us-east-1'
         # endpoint: http://localhost:9324
       encryption:
         algorithm: 'aes-256-ecb'
-        key: 'KMS key name'
+        key: 'alias/picard-sqs'
       schema:
         "id" : "#consumer-example-schema"
         properties:

--- a/examples/package.json
+++ b/examples/package.json
@@ -4,6 +4,7 @@
   "description": "AWS SDK Ext Examples",
   "main": "index.js",
   "scripts": {
+    "start": "node sqs/sqs-consumer-example.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/examples/package.json
+++ b/examples/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node sqs/sqs-consumer-example.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --debug sqs/sqs-consumer-example.js"
   },
   "author": "",
   "license": "ISC",

--- a/examples/sqs/sqs-consumer-example.js
+++ b/examples/sqs/sqs-consumer-example.js
@@ -27,7 +27,7 @@ const consumer = new SqsConsumerExample({
 
 consumer.on('running', () => {
   winston.info("SqsExample:: Sending test message");
-  return consumer.sendMessage({"id": 1, "test": "test"}, {"secretKey": "Secret Value"})
+  return consumer.sendMessage({"id": 1, "test": "test"} /*, {"secretKey": "Secret Value"} */)
     .catch(err => {
       winston.error(err);
       throw err;

--- a/examples/sqs/sqs-consumer-example.js
+++ b/examples/sqs/sqs-consumer-example.js
@@ -7,7 +7,7 @@ const SqsConsumer = require('aws-sdk-ext').sqs.SqsConsumer,
   config = require('config'),
   utils = require('aws-sdk-ext').utils;
 
-class SqsConsumerExample extends SqsConsumer{
+class SqsConsumerExample extends SqsConsumer {
   handle(msgBody) {
     winston.info(`SqsExample::${this.name}:: Handled message: ${JSON.stringify(msgBody)}`);
   }

--- a/examples/sqs/sqs-consumer-example.js
+++ b/examples/sqs/sqs-consumer-example.js
@@ -25,13 +25,9 @@ const consumer = new SqsConsumerExample({
 });
 
 
-
-
-
 consumer.on('running', () => {
-
   winston.info("SqsExample:: Sending test message");
-  return consumer.sendMessage({"id": 1, "test": "test"})
+  return consumer.sendMessage({"id": 1, "test": "test"}, {"secretKey": "Secret Value"})
     .catch(err => {
       winston.error(err);
       throw err;

--- a/lib/common/encryption.js
+++ b/lib/common/encryption.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const
-  CryptoJS = require('crypto-js');
+  AWS = require('aws-sdk'),
+  CryptoJS = require('crypto-js'),
+  error = require('./error');
 
 /**
  * @typedef  {object} EncryptedPayload
@@ -9,54 +11,88 @@ const
  * @property {string} key - The key used to encrypt the data
  */
 
-/**
- * Encrypts data using a key name.
- * @param  {*} data - The data to encrypt.
- * @param  {string} algorithm - The algorithm to use for encryption.
- * @param  {AWS.KMS} kms - An AWS KMS instance.
- * @param  {string} keyName - The name of the key to encrypt with.
- * @return {EncryptedPayload}
- */
-function encrypt(data, kms, keyName) {
-  let params = {
-    KeyId: keyName,
-    KeySpec: 'AES_256'
-  };
-  return kms.generateDataKey(params).promise()
-    .then(keys => {
-      let encryptedData = CryptoJS.AES.encrypt(JSON.stringify(data), keys.Plaintext).toString();
-      keys.Plaintext = null; // We want to explicitly wipe the plain text key from memory
+class EncryptionUtil {
 
-      return {
-        data: encryptedData,
-        key: keys.CiphertextBlob
-      };
-    });
+  /**
+   * Creates a new EncryptionUtil instance
+   * @param  {object} config - The configuration for the encryption
+   * @param  {string} config.key - The KMS key to use for encryption
+   * @param  {AWS.KMS} [kms] - The AWS KMS instance
+   * @return {EncryptionUtil}
+   */
+  constructor(config, kms) {
+    this.key = config && config.key;
+    this.kms = kms || new AWS.KMS();
+
+    if(!this.key) throw new error.EncryptionConfigurationError('key');
+  }
+
+  /**
+   * Encrypts data using a key name.
+   * @param  {*} data - The data to encrypt.
+   * @param  {string} algorithm - The algorithm to use for encryption.
+   * @param  {string} keyName - The name of the key to encrypt with.
+   * @return {EncryptedPayload}
+   */
+  encrypt(data) {
+    let params = {
+      KeyId: this.key,
+      KeySpec: 'AES_256'
+    };
+    return this.kms.generateDataKey(params).promise()
+      .then(keys => {
+        keys.Plaintext = this._bufferToHex(keys.Plaintext);
+        keys.CiphertextBlob = this._bufferToHex(keys.CiphertextBlob);
+        return keys;
+      })
+      .then(keys => {
+          let encryptedData = CryptoJS.AES.encrypt(JSON.stringify(data), keys.Plaintext).toString();
+          keys.Plaintext = null; // We want to explicitly wipe the plain text key from memory
+
+          return {
+            data: encryptedData,
+            key: keys.CiphertextBlob
+          };
+      });
+  }
+
+  /**
+   * Decrypts the data using the given key.
+   * @param  {EncryptedPayload} encryptedPayload - The encrypted payload.
+   * @param  {string} algorithm - The algorithm to use for decryption.
+   * @param  {AWS.KMS} kms - An AWS KMS instance.
+   * @return {*} - The decrypted data.
+   */
+  decrypt(encryptedPayload) {
+    let params = {
+      CiphertextBlob: this._hexToBuffer(encryptedPayload.key) // This needs to be a uint8array
+    };
+
+    return this.kms.decrypt(params).promise()
+      .then(decryptedKey => {
+        let key = this._bufferToHex(decryptedKey.Plaintext);
+        let bytes  = CryptoJS.AES.decrypt(encryptedPayload.data, key);
+        let decryptedData = JSON.parse(bytes.toString(CryptoJS.enc.Utf8));
+
+        decryptedKey = null; // We want to explicitly wipe the plain text key from memory
+
+        return decryptedData;
+      });
+  }
+
+  get config() {
+    return {
+      key: this.key
+    };
+  }
+
+  _bufferToHex(buffer) {
+    return buffer.toString('hex');
+  }
+
+  _hexToBuffer(hex) {
+    return Buffer.from(hex, 'hex');
+  }
 }
 
-/**
- * Decrypts the data using the given key.
- * @param  {EncryptedPayload} encryptedPayload - The encrypted payload.
- * @param  {string} algorithm - The algorithm to use for decryption.
- * @param  {AWS.KMS} kms - An AWS KMS instance.
- * @return {*} - The decrypted data.
- */
-function decrypt(encryptedPayload, kms) {
-  let params = {
-    CiphertextBlob: encryptedPayload.key
-  };
-  return kms.decrypt(params).promise()
-    .then(decryptedKey => {
-      let bytes  = CryptoJS.AES.decrypt(encryptedPayload.data, decryptedKey);
-      let decryptedData = JSON.parse(bytes.toString(CryptoJS.enc.Utf8));
-
-      decryptedKey = null; // We want to explicitly wipe the plain text key from memory
-
-      return decryptedData;
-    });
-}
-
-module.exports = {
-  encrypt,
-  decrypt
-};
+module.exports = EncryptionUtil;

--- a/lib/common/encryption.js
+++ b/lib/common/encryption.js
@@ -41,8 +41,8 @@ class EncryptionUtil {
     };
     return this.kms.generateDataKey(params).promise()
       .then(keys => {
-        keys.Plaintext = this._bufferToHex(keys.Plaintext);
-        keys.CiphertextBlob = this._bufferToHex(keys.CiphertextBlob);
+        keys.Plaintext = keys.Plaintext.toString('hex');
+        keys.CiphertextBlob = keys.CiphertextBlob.toString('hex');
         return keys;
       })
       .then(keys => {
@@ -65,33 +65,23 @@ class EncryptionUtil {
    */
   decrypt(encryptedPayload) {
     let params = {
-      CiphertextBlob: this._hexToBuffer(encryptedPayload.key) // This needs to be a uint8array
+      CiphertextBlob: Buffer.from(encryptedPayload.key, 'hex')
     };
 
     return this.kms.decrypt(params).promise()
       .then(decryptedKey => {
-        let key = this._bufferToHex(decryptedKey.Plaintext);
+        let key = decryptedKey.Plaintext.toString('hex');
+        decryptedKey.Plaintext = null; // We want to explicitly wipe the plain text key from memory
+
         let bytes  = CryptoJS.AES.decrypt(encryptedPayload.data, key);
-        let decryptedData = JSON.parse(bytes.toString(CryptoJS.enc.Utf8));
+        let dataString = bytes.toString(CryptoJS.enc.Utf8);
 
-        decryptedKey = null; // We want to explicitly wipe the plain text key from memory
-
-        return decryptedData;
+        try {
+          return JSON.parse(dataString);
+        } catch(e) {
+          return dataString;
+        }
       });
-  }
-
-  get config() {
-    return {
-      key: this.key
-    };
-  }
-
-  _bufferToHex(buffer) {
-    return buffer.toString('hex');
-  }
-
-  _hexToBuffer(hex) {
-    return Buffer.from(hex, 'hex');
   }
 }
 

--- a/lib/common/encryption.js
+++ b/lib/common/encryption.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const
+  AWS = require('aws-sdk'),
+  crypto = require('crypto');
+
+/**
+ * @typedef  {object} EncryptedPayload
+ * @property {string} data - The encrypted data
+ * @property {string} key - The key used to encrypt the data
+ */
+
+/**
+ * Encrypts data using a key name.
+ * @param  {*} data - The data to encrypt.
+ * @param  {string} algorithm - The algorithm to use for encryption.
+ * @param  {AWS.KMS} kms - An AWS KMS instance.
+ * @param  {string} keyName - The name of the key to encrypt with.
+ * @return {EncryptedPayload}
+ */
+function encrypt(data, algorithm, kms, keyName) {
+  let params = {
+    KeyId: keyName,
+    KeySpec: 'AES_256'
+  };
+  return kms.generateDataKey(params).promise()
+    .then(keys => {
+      // Create a cipher and encrypt the data
+      let cipher = crypto.createCipher(algorithm, keys.Plaintext);
+      let encryptedData = cipher.update(JSON.stringify(data), 'uft8', 'base64');
+      encryptedData += cipher.final('base64');
+
+      // We want to explicitly wipe the plain text key from memory
+      keys.Plaintext = null;
+
+      return {
+        data: encryptedData,
+        key: keys.CiphertextBlob
+      };
+    });
+}
+
+/**
+ * Decrypts the data using the given key.
+ * @param  {EncryptedPayload} encryptedPayload - The encrypted payload.
+ * @param  {string} algorithm - The algorithm to use for decryption.
+ * @param  {AWS.KMS} kms - An AWS KMS instance.
+ * @return {*} - The decrypted data.
+ */
+function decrypt(encryptedPayload, algorithm, kms) {
+  let params = {
+    CiphertextBlob: encryptedPayload.key
+  };
+  return kms.decrypt(params).promise()
+    .then(decryptedKey => {
+      // Create a decipher and decrypt the data
+      let decipher = crypto.createDecipher(algorithm, decryptedKey);
+      let decryptedData = decipher.update(encryptedPayload.data, 'base64', 'utf8');
+      decryptedData += decipher.final('utf8');
+
+      // We want to explicitly wipe the plain text key from memory
+      decryptedKey = null;
+
+      return JSON.parse(decryptedData);
+    });
+}

--- a/lib/common/encryption.js
+++ b/lib/common/encryption.js
@@ -64,3 +64,8 @@ function decrypt(encryptedPayload, algorithm, kms) {
       return JSON.parse(decryptedData);
     });
 }
+
+module.exports = {
+  encrypt,
+  decrypt
+};

--- a/lib/common/encryption.js
+++ b/lib/common/encryption.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const
-  AWS = require('aws-sdk'),
-  crypto = require('crypto');
+  CryptoJS = require('crypto-js');
 
 /**
  * @typedef  {object} EncryptedPayload
@@ -18,20 +17,15 @@ const
  * @param  {string} keyName - The name of the key to encrypt with.
  * @return {EncryptedPayload}
  */
-function encrypt(data, algorithm, kms, keyName) {
+function encrypt(data, kms, keyName) {
   let params = {
     KeyId: keyName,
     KeySpec: 'AES_256'
   };
   return kms.generateDataKey(params).promise()
     .then(keys => {
-      // Create a cipher and encrypt the data
-      let cipher = crypto.createCipher(algorithm, keys.Plaintext);
-      let encryptedData = cipher.update(JSON.stringify(data), 'uft8', 'base64');
-      encryptedData += cipher.final('base64');
-
-      // We want to explicitly wipe the plain text key from memory
-      keys.Plaintext = null;
+      let encryptedData = CryptoJS.AES.encrypt(JSON.stringify(data), keys.Plaintext).toString();
+      keys.Plaintext = null; // We want to explicitly wipe the plain text key from memory
 
       return {
         data: encryptedData,
@@ -47,21 +41,18 @@ function encrypt(data, algorithm, kms, keyName) {
  * @param  {AWS.KMS} kms - An AWS KMS instance.
  * @return {*} - The decrypted data.
  */
-function decrypt(encryptedPayload, algorithm, kms) {
+function decrypt(encryptedPayload, kms) {
   let params = {
     CiphertextBlob: encryptedPayload.key
   };
   return kms.decrypt(params).promise()
     .then(decryptedKey => {
-      // Create a decipher and decrypt the data
-      let decipher = crypto.createDecipher(algorithm, decryptedKey);
-      let decryptedData = decipher.update(encryptedPayload.data, 'base64', 'utf8');
-      decryptedData += decipher.final('utf8');
+      let bytes  = CryptoJS.AES.decrypt(encryptedPayload.data, decryptedKey);
+      let decryptedData = JSON.parse(bytes.toString(CryptoJS.enc.Utf8));
 
-      // We want to explicitly wipe the plain text key from memory
-      decryptedKey = null;
+      decryptedKey = null; // We want to explicitly wipe the plain text key from memory
 
-      return JSON.parse(decryptedData);
+      return decryptedData;
     });
 }
 

--- a/lib/common/error.js
+++ b/lib/common/error.js
@@ -25,7 +25,7 @@ class NonRetryableError extends BaseError {
 
 class EncryptionConfigurationError extends BaseError {
   constructor(config) {
-    super(`An encryption configuration was not found or missing a property. Config: ${encryptionConfig}`);
+    super(`An encryption configuration was not found or missing a property. Config: ${JSON.stringify(config)}`);
     Error.captureStackTrace(this, EncryptionConfigurationError);
   }
 }

--- a/lib/common/error.js
+++ b/lib/common/error.js
@@ -23,8 +23,16 @@ class NonRetryableError extends BaseError {
   }
 }
 
+class EncryptionConfigurationError extends BaseError {
+  constructor(encryptionConfig) {
+    super('An encryption configuration was not found in the config.');
+    Error.captureStackTrace(this, EncryptionConfigurationError);
+  }
+}
+
 module.exports = {
   BaseError: BaseError,
   ValidationError : ValidationError,
-  NonRetryableError: NonRetryableError
+  NonRetryableError: NonRetryableError,
+  EncryptionConfigurationError
 };

--- a/lib/common/error.js
+++ b/lib/common/error.js
@@ -24,8 +24,8 @@ class NonRetryableError extends BaseError {
 }
 
 class EncryptionConfigurationError extends BaseError {
-  constructor(config) {
-    super(`An encryption configuration was not found or missing a property. Config: ${JSON.stringify(config)}`);
+  constructor(missingProperty) {
+    super(`An encryption configuration was not found or missing a property. Property: encryption.${missingProperty}`);
     Error.captureStackTrace(this, EncryptionConfigurationError);
   }
 }

--- a/lib/common/error.js
+++ b/lib/common/error.js
@@ -24,8 +24,8 @@ class NonRetryableError extends BaseError {
 }
 
 class EncryptionConfigurationError extends BaseError {
-  constructor(encryptionConfig) {
-    super('An encryption configuration was not found in the config.');
+  constructor(config) {
+    super(`An encryption configuration was not found or missing a property. Config: ${encryptionConfig}`);
     Error.captureStackTrace(this, EncryptionConfigurationError);
   }
 }

--- a/lib/sqs/sqs-base.js
+++ b/lib/sqs/sqs-base.js
@@ -10,7 +10,7 @@ const
   commonUtils = require('../common/utils'),
   ValidationUtil = require('../common/validation'),
   error = require('../common/error'),
-  encryption = require('../common/encryption'),
+  EncryptionUtil = require('../common/encryption'),
   events = require('events'),
   AWS = require('aws-sdk');
 
@@ -59,10 +59,10 @@ class SqsBase extends events.EventEmitter {
     this.conf = _.merge({}, awsext.sqs.defaults, awsext.sqs[this.name], options.conf);
     this._sqs = options.sqs || new AWS.SQS(this.conf.sqsOptions);
     this._kms = options.kms || new AWS.KMS(this.conf.kmsOptions);
-    this._encryption = this.conf.encryption;
     this._queueName = this.conf.queue.prefix + this.conf.queue.env;
     this._queueUrl = null; //Initialized using AWS Lookup
     this.validationUtil = options.validationUtil || new ValidationUtil();
+    this.encryptionUtil = options.encryptionUtil || new EncryptionUtil(this.conf.encryption, this._kms);
   }
 
   status() {
@@ -101,15 +101,11 @@ class SqsBase extends events.EventEmitter {
     return this._init()
       .then(() => {
         if(!_.isEmpty(sensitiveMsgData)) {
-          if(hasEncryptionConfig) {
-            let tempMsg = _.merge({}, msgData, sensitiveMsgData); // create a temp object and validate it before encrypting...
+          let tempMsg = _.merge({}, msgData, sensitiveMsgData); // create a temp object and validate it before encrypting...
 
-            return this.validateMessage(tempMsg)
-              .then(() => this._encrypt(sensitiveMsgData)) // encrypt the message...
-              .then(encryptedPayload => _.merge({}, msgData, {encrypted: encryptedPayload})); // and attach it to the message
-          } else {
-            throw new error.EncryptionConfigurationError(this._encryption);
-          }
+          return this.validateMessage(tempMsg)
+            .then(() => this._encrypt(sensitiveMsgData)) // encrypt the message...
+            .then(encryptedPayload => _.merge({}, msgData, {encrypted: encryptedPayload})); // and attach it to the message
         }
 
         // else just validate the normal message
@@ -166,12 +162,11 @@ class SqsBase extends events.EventEmitter {
   }
 
   _encrypt(data) {
-    let key = this._encryption.key;
-    return encryption.encrypt(data, this._kms, key);
+    return this.encryptionUtil.encrypt(data);
   }
 
   _decrypt(encryptedPayload) {
-    return encryption.decrypt(encryptedPayload, this._kms);
+    return this.encryptionUtil.decrypt(encryptedPayload);
   }
 }
 

--- a/lib/sqs/sqs-base.js
+++ b/lib/sqs/sqs-base.js
@@ -97,30 +97,29 @@ class SqsBase extends events.EventEmitter {
    * @param {object} [msgToEncrypt] - An optional message to encrypt alongside the original message
    */
   sendMessage(msgData, msgToEncrypt) {
-    let promise = this._init()
-      .then(() => msgData);
-
-    // Check if the configuration for encryption has been set
     let hasEncryptionConfig = this._encryption && this._encryption.algorithm && this._encryption.key;
 
-    // If there's data to encrypt...
-    if(!_.isEmpty(msgToEncrypt) && hasEncryptionConfig) {
-      let tempMsg = _.merge({}, msgData, msgToEncrypt); // create a temp object and validate it before encrypting...
-      promise.then(this.validateMessage(tempMsg))
-        .then(this._encrypt(msgToEncrypt)) // encrypt the message...
-        .then(encryptedPayload => _.merge({}, msgData, {encrypted: encryptedPayload})); // and attach it to the message
+    return this._init()
+      .then(() => msgData)
+      .then(msgData => {
+        if(!_.isEmpty(msgToEncrypt) && hasEncryptionConfig) {
+          let tempMsg = _.merge({}, msgData, msgToEncrypt); // create a temp object and validate it before encrypting...
 
-    // else just validate the normal message
-    } else {
-      promise.then(this.validateMessage(msgData))
-        .then(() => msgData);
-    }
+          return this.validateMessage(tempMsg)
+            .then(() => this._encrypt(msgToEncrypt)) // encrypt the message...
+            .then(encryptedPayload => _.merge({}, msgData, {encrypted: encryptedPayload})); // and attach it to the message
+        }
 
-    return promise
-      .then(sqsMsg => this._sqs.sendMessage ({
-        MessageBody: JSON.stringify(sqsMsg),
-        QueueUrl: this._queueUrl,
-      }).promise())
+        // else just validate the normal message
+        return this.validateMessage(msgData)
+          .then(() => msgData);
+      })
+      .then(sqsMsg => {
+        return this._sqs.sendMessage({
+          MessageBody: JSON.stringify(sqsMsg),
+          QueueUrl: this._queueUrl,
+        }).promise();
+      })
       .then(() => {
         this.emit('sent', msgData);
       })
@@ -167,7 +166,7 @@ class SqsBase extends events.EventEmitter {
   _encrypt(data) {
     let algorithm = this._encryption.algorithm;
     let key = this._encryption.key;
-    return encryption.encrypt(data, algorithm, key, this._kms);
+    return encryption.encrypt(data, algorithm, this._kms, key);
   }
 
   _decrypt(encryptedPayload) {

--- a/lib/sqs/sqs-base.js
+++ b/lib/sqs/sqs-base.js
@@ -56,12 +56,11 @@ class SqsBase extends events.EventEmitter {
     options = options || {};
     this.name = options.name || 'sqs-default';
 
-    // TODO: Figure out final place for algorithm and key name configuration
-
     let awsext = _.merge({}, DEFAULT_BASE_AWS_EXT_CONFIG, defaultAwsExtConfig, config.awsext);
     this.conf = _.merge({}, awsext.sqs.defaults, awsext.sqs[this.name], options.conf);
     this._sqs = options.sqs || new AWS.SQS(this.conf.sqsOptions);
     this._kms = options.kms || new AWS.KMS(this.conf.kmsOptions);
+    this._encryption = this.conf.encryption;
     this._queueName = this.conf.queue.prefix + this.conf.queue.env;
     this._queueUrl = null; //Initialized using AWS Lookup
     this.validationUtil = options.validationUtil || new ValidationUtil();
@@ -100,11 +99,17 @@ class SqsBase extends events.EventEmitter {
   sendMessage(msgData, msgToEncrypt) {
     let promise = this._init();
 
-    if(!_.isEmpty(msgToEncrypt)) {
-      let tempMsg = _.merge({}, msgData, msgToEncrypt);
+    // Check if the configuration for encryption has been set
+    let hasEncryptionConfig = !_.isEmpty(this._encryption.algorithm) && !_.isEmpty(this._encryption.key);
+
+    // If there's data to encrypt...
+    if(!_.isEmpty(msgToEncrypt) && hasEncryptionConfig) {
+      let tempMsg = _.merge({}, msgData, msgToEncrypt); // create a temp object and validate it before encrypting...
       promise.then(this.validateMessage(tempMsg))
-        .then(this._encrypt(msgToEncrypt))
-        .then(encryptedPayload => _.merge({}, msgData, {encrypted: encryptedPayload}));
+        .then(this._encrypt(msgToEncrypt)) // encrypt the message...
+        .then(encryptedPayload => _.merge({}, msgData, {encrypted: encryptedPayload})); // and attach it to the message
+
+    // else just validate the normal message
     } else {
       promise.then(this.validateMessage(msgData))
         .then(() => msgData);
@@ -159,13 +164,13 @@ class SqsBase extends events.EventEmitter {
   }
 
   _encrypt(data) {
-    let algorithm = 'aes-256-ecb'; // TODO: Get algorithm from the config
-    let keyName = 'key name'; // TODO: Get the config from the key name
-    return encryption.encrypt(data, algorithm, keyName, this._kms);
+    let algorithm = this._encryption.algorithm;
+    let key = this._encryption.key;
+    return encryption.encrypt(data, algorithm, key, this._kms);
   }
 
   _decrypt(encryptedPayload) {
-    let algorithm = 'aes-256-ecb'; // TODO: Get algorithm from the config
+    let algorithm = this._encryption.algorithm;
     return encryption.decrypt(encryptedPayload, algorithm, this._kms);
   }
 }

--- a/lib/sqs/sqs-base.js
+++ b/lib/sqs/sqs-base.js
@@ -5,11 +5,13 @@ require('promise.prototype.finally');
 const
   promisify = require("es6-promisify"),
   config = require("config"),
+  crypto = require('crypto'),
   _ = require('lodash'),
   winston = require('winston'),
   commonUtils = require('../common/utils'),
   ValidationUtil = require('../common/validation'),
   error = require('../common/error'),
+  encryption = require('../common/encryption'),
   events = require('events'),
   AWS = require('aws-sdk');
 
@@ -54,9 +56,12 @@ class SqsBase extends events.EventEmitter {
     options = options || {};
     this.name = options.name || 'sqs-default';
 
+    // TODO: Figure out final place for algorithm and key name configuration
+
     let awsext = _.merge({}, DEFAULT_BASE_AWS_EXT_CONFIG, defaultAwsExtConfig, config.awsext);
     this.conf = _.merge({}, awsext.sqs.defaults, awsext.sqs[this.name], options.conf);
     this._sqs = options.sqs || new AWS.SQS(this.conf.sqsOptions);
+    this._kms = options.kms || new AWS.KMS(this.conf.kmsOptions);
     this._queueName = this.conf.queue.prefix + this.conf.queue.env;
     this._queueUrl = null; //Initialized using AWS Lookup
     this.validationUtil = options.validationUtil || new ValidationUtil();
@@ -89,19 +94,31 @@ class SqsBase extends events.EventEmitter {
 
   /**
    * Validates and sends message to queue
-   * @param msgData
+   * @param {object} msgData - The message to send to the queue
+   * @param {object} [msgToEncrypt] - An optional message to encrypt alongside the original message
    */
-  sendMessage(msgData) {
-    return this._init()
-      .then( () => this.validateMessage(msgData))
-      .then( () => this._sqs.sendMessage ({
-        MessageBody: JSON.stringify(msgData),
+  sendMessage(msgData, msgToEncrypt) {
+    let promise = this._init();
+
+    if(!_.isEmpty(msgToEncrypt)) {
+      let tempMsg = _.merge({}, msgData, msgToEncrypt);
+      promise.then(this.validateMessage(tempMsg))
+        .then(this._encrypt(msgToEncrypt))
+        .then(encryptedPayload => _.merge({}, msgData, {encrypted: encryptedPayload}));
+    } else {
+      promise.then(this.validateMessage(msgData))
+        .then(() => msgData);
+    }
+
+    return promise
+      .then(sqsMsg => this._sqs.sendMessage ({
+        MessageBody: JSON.stringify(sqsMsg),
         QueueUrl: this._queueUrl,
       }).promise())
-      .then ( () => {
+      .then(() => {
         this.emit('sent', msgData);
       })
-      .catch ( err => {
+      .catch(err => {
         this.emit('sent-failed', err);
         throw err;
       });
@@ -140,6 +157,18 @@ class SqsBase extends events.EventEmitter {
     }
     return Promise.resolve();
   }
+
+  _encrypt(data) {
+    let algorithm = 'aes-256-ecb'; // TODO: Get algorithm from the config
+    let keyName = 'key name'; // TODO: Get the config from the key name
+    return encryption.encrypt(data, algorithm, keyName, this._kms);
+  }
+
+  _decrypt(encryptedPayload) {
+    let algorithm = 'aes-256-ecb'; // TODO: Get algorithm from the config
+    return encryption.decrypt(encryptedPayload, algorithm, this._kms);
+  }
 }
+
 
 module.exports = SqsBase;

--- a/lib/sqs/sqs-base.js
+++ b/lib/sqs/sqs-base.js
@@ -3,9 +3,8 @@
 require('promise.prototype.finally');
 
 const
-  promisify = require("es6-promisify"),
-  config = require("config"),
-  crypto = require('crypto'),
+  promisify = require('es6-promisify'),
+  config = require('config'),
   _ = require('lodash'),
   winston = require('winston'),
   commonUtils = require('../common/utils'),
@@ -97,7 +96,7 @@ class SqsBase extends events.EventEmitter {
    * @param {object} [sensitiveMsgData] - An optional message to encrypt alongside the original message
    */
   sendMessage(msgData, sensitiveMsgData) {
-    let hasEncryptionConfig = this._encryption && this._encryption.algorithm && this._encryption.key;
+    let hasEncryptionConfig = this._encryption && this._encryption.key;
 
     return this._init()
       .then(() => {
@@ -167,17 +166,12 @@ class SqsBase extends events.EventEmitter {
   }
 
   _encrypt(data) {
-    let algorithm = this._encryption.algorithm;
     let key = this._encryption.key;
-    return encryption.encrypt(data, algorithm, this._kms, key);
+    return encryption.encrypt(data, this._kms, key);
   }
 
   _decrypt(encryptedPayload) {
-    let algorithm = this._encryption.algorithm;
-    return encryption.decrypt(encryptedPayload, algorithm, this._kms)
-      .then(decryptedData => {
-        return decryptedData;
-      });
+    return encryption.decrypt(encryptedPayload, this._kms);
   }
 }
 

--- a/lib/sqs/sqs-base.js
+++ b/lib/sqs/sqs-base.js
@@ -174,7 +174,10 @@ class SqsBase extends events.EventEmitter {
 
   _decrypt(encryptedPayload) {
     let algorithm = this._encryption.algorithm;
-    return encryption.decrypt(encryptedPayload, algorithm, this._kms);
+    return encryption.decrypt(encryptedPayload, algorithm, this._kms)
+      .then(decryptedData => {
+        return decryptedData;
+      });
   }
 }
 

--- a/lib/sqs/sqs-base.js
+++ b/lib/sqs/sqs-base.js
@@ -94,20 +94,23 @@ class SqsBase extends events.EventEmitter {
   /**
    * Validates and sends message to queue
    * @param {object} msgData - The message to send to the queue
-   * @param {object} [msgToEncrypt] - An optional message to encrypt alongside the original message
+   * @param {object} [sensitiveMsgData] - An optional message to encrypt alongside the original message
    */
-  sendMessage(msgData, msgToEncrypt) {
+  sendMessage(msgData, sensitiveMsgData) {
     let hasEncryptionConfig = this._encryption && this._encryption.algorithm && this._encryption.key;
 
     return this._init()
-      .then(() => msgData)
-      .then(msgData => {
-        if(!_.isEmpty(msgToEncrypt) && hasEncryptionConfig) {
-          let tempMsg = _.merge({}, msgData, msgToEncrypt); // create a temp object and validate it before encrypting...
+      .then(() => {
+        if(!_.isEmpty(sensitiveMsgData)) {
+          if(hasEncryptionConfig) {
+            let tempMsg = _.merge({}, msgData, sensitiveMsgData); // create a temp object and validate it before encrypting...
 
-          return this.validateMessage(tempMsg)
-            .then(() => this._encrypt(msgToEncrypt)) // encrypt the message...
-            .then(encryptedPayload => _.merge({}, msgData, {encrypted: encryptedPayload})); // and attach it to the message
+            return this.validateMessage(tempMsg)
+              .then(() => this._encrypt(sensitiveMsgData)) // encrypt the message...
+              .then(encryptedPayload => _.merge({}, msgData, {encrypted: encryptedPayload})); // and attach it to the message
+          } else {
+            throw new error.EncryptionConfigurationError(this._encryption);
+          }
         }
 
         // else just validate the normal message
@@ -118,10 +121,10 @@ class SqsBase extends events.EventEmitter {
         return this._sqs.sendMessage({
           MessageBody: JSON.stringify(sqsMsg),
           QueueUrl: this._queueUrl,
-        }).promise();
-      })
-      .then(() => {
-        this.emit('sent', msgData);
+        }).promise()
+        .then(() => {
+          this.emit('sent', sqsMsg);
+        });
       })
       .catch(err => {
         this.emit('sent-failed', err);

--- a/lib/sqs/sqs-base.js
+++ b/lib/sqs/sqs-base.js
@@ -97,10 +97,11 @@ class SqsBase extends events.EventEmitter {
    * @param {object} [msgToEncrypt] - An optional message to encrypt alongside the original message
    */
   sendMessage(msgData, msgToEncrypt) {
-    let promise = this._init();
+    let promise = this._init()
+      .then(() => msgData);
 
     // Check if the configuration for encryption has been set
-    let hasEncryptionConfig = !_.isEmpty(this._encryption.algorithm) && !_.isEmpty(this._encryption.key);
+    let hasEncryptionConfig = this._encryption && this._encryption.algorithm && this._encryption.key;
 
     // If there's data to encrypt...
     if(!_.isEmpty(msgToEncrypt) && hasEncryptionConfig) {

--- a/lib/sqs/sqs-consumer.js
+++ b/lib/sqs/sqs-consumer.js
@@ -123,27 +123,9 @@ class SqsConsumer extends SqsBase {
 
   _handle(message) {
     winston.info(`SqsConsumer::${this.name}:: Processing message: ${message.MessageId}`);
-    let possiblyEncryptedMsg = JSON.parse(message.Body);
-    let promise = Promise.resolve(possiblyEncryptedMsg);
 
-    // Check if the configuration for encryption has been set
-    let hasEncryptionConfig = this._encryption && this._encryption.algorithm && this._encryption.key;
-
-    // If the message has encrypted properties...
-    if(possiblyEncryptedMsg.encrypted) {
-      if(hasEncryptionConfig) {
-        promise
-          .then(this._decrypt(possiblyEncryptedMsg.encrypted)) // decrypt it...
-          .then(decryptedData => {
-            possiblyEncryptedMsg.encrypted = undefined;
-            return _.merge({}, possiblyEncryptedMsg, decryptedData); // and merge it into the message body
-          });
-      } else {
-        throw new error.EncryptionConfigurationError(this._encryption);
-      }
-    }
-
-    return promise
+    return Promise.resolve(JSON.parse(message.Body))
+      .then(messageBody => this._decryptMessage(messageBody))
       .then(messageBody => this.validateMessage(messageBody))
       .then(messageBody => this.handle(messageBody))
       .then( ()=> this._sqs.deleteMessage({
@@ -270,6 +252,31 @@ class SqsConsumer extends SqsBase {
     }
 
     return Promise.resolve(data);
+  }
+
+  /**
+   * Will decrypt the message body
+   * @param  {object} messageBody The SQS message body
+   * @return {object} The decrypted message body. If there was no encrypted data, returns messageBody.
+   */
+  _decryptMessage(messageBody) {
+    // If the message has encrypted properties...
+    if(messageBody.encrypted) {
+      // Check if the configuration for encryption has been set
+      let hasEncryptionConfig = this._encryption && this._encryption.algorithm && this._encryption.key;
+
+      if(hasEncryptionConfig) {
+        return this._decrypt(messageBody.encrypted) // decrypt it...
+          .then(decryptedData => {
+            messageBody.encrypted = undefined;
+            return _.merge({}, messageBody, decryptedData); // and merge it into the message body
+          });
+      } else {
+        return Promise.reject(new error.EncryptionConfigurationError(this._encryption));
+      }
+    }
+     // Return the original message body if there was nothing to decrypt
+    return Promise.resolve(messageBody);
   }
 
   /**

--- a/lib/sqs/sqs-consumer.js
+++ b/lib/sqs/sqs-consumer.js
@@ -123,18 +123,21 @@ class SqsConsumer extends SqsBase {
 
   _handle(message) {
     winston.info(`SqsConsumer::${this.name}:: Processing message: ${message.MessageId}`);
-    let promise = Promise.resolve(JSON.parse(message.Body));
+    let possiblyEncryptedMsg = JSON.parse(message.Body);
+    let promise = Promise.resolve(possiblyEncryptedMsg);
 
-    promise.then(messageBody => {
-      // If there's encrypted data...
-      if(messageBody.encrypted) {
-        return this._decrypt(messageBody.encrypted) // decrypt it...
-          .then(decryptedData => {
-            messageBody.encrypted = undefined;
-            return _.merge({}, messageBody, decryptedData); // and merge it into the message body
-          });
-      }
-    });
+    // Check if the configuration for encryption has been set
+    let hasEncryptionConfig = !_.isEmpty(this._encryption.algorithm) && !_.isEmpty(this._encryption.key);
+
+    // If the message has encrypted properties...
+    if(possiblyEncryptedMsg.encrypted && hasEncryptionConfig) {
+      promise
+        .then(this._decrypt(possiblyEncryptedMsg.encrypted)) // decrypt it...
+        .then(decryptedData => {
+          possiblyEncryptedMsg.encrypted = undefined;
+          return _.merge({}, possiblyEncryptedMsg, decryptedData); // and merge it into the message body
+        });
+    }
 
     return promise
       .then(messageBody => this.validateMessage(messageBody))

--- a/lib/sqs/sqs-consumer.js
+++ b/lib/sqs/sqs-consumer.js
@@ -263,7 +263,7 @@ class SqsConsumer extends SqsBase {
     // If the message has encrypted properties...
     if(messageBody.encrypted) {
       // Check if the configuration for encryption has been set
-      let hasEncryptionConfig = this._encryption && this._encryption.algorithm && this._encryption.key;
+      let hasEncryptionConfig = this._encryption && this._encryption.key;
 
       if(hasEncryptionConfig) {
         return this._decrypt(messageBody.encrypted) // decrypt it...

--- a/lib/sqs/sqs-consumer.js
+++ b/lib/sqs/sqs-consumer.js
@@ -8,6 +8,7 @@ const
   _ = require('lodash'),
   winston = require('winston'),
   commonUtils = require('../common/utils'),
+  encryption = require('../common/encryption'),
   getVisibilityTimeout = commonUtils.getVisibilityTimeout,
   readDuration = commonUtils.readDuration,
   error = require('../common/error'),
@@ -122,7 +123,20 @@ class SqsConsumer extends SqsBase {
 
   _handle(message) {
     winston.info(`SqsConsumer::${this.name}:: Processing message: ${message.MessageId}`);
-    return Promise.resolve(JSON.parse(message.Body))
+    let promise = Promise.resolve(JSON.parse(message.Body));
+
+    promise.then(messageBody => {
+      // If there's encrypted data...
+      if(messageBody.encrypted) {
+        return this._decrypt(messageBody.encrypted) // decrypt it...
+          .then(decryptedData => {
+            messageBody.encrypted = undefined;
+            return _.merge({}, messageBody, decryptedData); // and merge it into the message body
+          });
+      }
+    });
+
+    return promise
       .then(messageBody => this.validateMessage(messageBody))
       .then(messageBody => this.handle(messageBody))
       .then( ()=> this._sqs.deleteMessage({

--- a/lib/sqs/sqs-consumer.js
+++ b/lib/sqs/sqs-consumer.js
@@ -130,13 +130,17 @@ class SqsConsumer extends SqsBase {
     let hasEncryptionConfig = this._encryption && this._encryption.algorithm && this._encryption.key;
 
     // If the message has encrypted properties...
-    if(possiblyEncryptedMsg.encrypted && hasEncryptionConfig) {
-      promise
-        .then(this._decrypt(possiblyEncryptedMsg.encrypted)) // decrypt it...
-        .then(decryptedData => {
-          possiblyEncryptedMsg.encrypted = undefined;
-          return _.merge({}, possiblyEncryptedMsg, decryptedData); // and merge it into the message body
-        });
+    if(possiblyEncryptedMsg.encrypted) {
+      if(hasEncryptionConfig) {
+        promise
+          .then(this._decrypt(possiblyEncryptedMsg.encrypted)) // decrypt it...
+          .then(decryptedData => {
+            possiblyEncryptedMsg.encrypted = undefined;
+            return _.merge({}, possiblyEncryptedMsg, decryptedData); // and merge it into the message body
+          });
+      } else {
+        throw new error.EncryptionConfigurationError(this._encryption);
+      }
     }
 
     return promise

--- a/lib/sqs/sqs-consumer.js
+++ b/lib/sqs/sqs-consumer.js
@@ -127,7 +127,7 @@ class SqsConsumer extends SqsBase {
     let promise = Promise.resolve(possiblyEncryptedMsg);
 
     // Check if the configuration for encryption has been set
-    let hasEncryptionConfig = !_.isEmpty(this._encryption.algorithm) && !_.isEmpty(this._encryption.key);
+    let hasEncryptionConfig = this._encryption && this._encryption.algorithm && this._encryption.key;
 
     // If the message has encrypted properties...
     if(possiblyEncryptedMsg.encrypted && hasEncryptionConfig) {

--- a/lib/sqs/sqs-consumer.js
+++ b/lib/sqs/sqs-consumer.js
@@ -262,18 +262,11 @@ class SqsConsumer extends SqsBase {
   _decryptMessage(messageBody) {
     // If the message has encrypted properties...
     if(messageBody.encrypted) {
-      // Check if the configuration for encryption has been set
-      let hasEncryptionConfig = this._encryption && this._encryption.key;
-
-      if(hasEncryptionConfig) {
-        return this._decrypt(messageBody.encrypted) // decrypt it...
-          .then(decryptedData => {
-            delete messageBody.encrypted;
-            return _.merge({}, messageBody, decryptedData); // and merge it into the message body
-          });
-      } else {
-        return Promise.reject(new error.EncryptionConfigurationError(this._encryption));
-      }
+      return this._decrypt(messageBody.encrypted) // decrypt it...
+        .then(decryptedData => {
+          delete messageBody.encrypted;
+          return _.merge({}, messageBody, decryptedData); // and merge it into the message body
+        });
     }
      // Return the original message body if there was nothing to decrypt
     return Promise.resolve(messageBody);

--- a/lib/sqs/sqs-consumer.js
+++ b/lib/sqs/sqs-consumer.js
@@ -268,7 +268,7 @@ class SqsConsumer extends SqsBase {
       if(hasEncryptionConfig) {
         return this._decrypt(messageBody.encrypted) // decrypt it...
           .then(decryptedData => {
-            messageBody.encrypted = undefined;
+            delete messageBody.encrypted;
             return _.merge({}, messageBody, decryptedData); // and merge it into the message body
           });
       } else {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jshint": "^2.9.2",
     "jshint-stylish": "^2.2.0",
     "mocha": "^3.0.2",
-    "sinon": "^1.17.5",
-    "sinon-chai": "^2.8.0"
+    "sinon": "^2.1.0",
+    "sinon-chai": "^2.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "aws-sdk": "^2.4.13",
     "config": "^1.21.0",
+    "crypto-js": "^3.1.9-1",
     "es6-promisify": "^4.1.0",
     "human-interval": "^0.1.6",
     "js-yaml": "^3.6.1",

--- a/test/unit/common/encryption-spec.js
+++ b/test/unit/common/encryption-spec.js
@@ -1,0 +1,95 @@
+"use strict";
+
+require('../../init-chai');
+
+/* jshint expr: true */
+
+const
+  crypto = require('crypto'),
+  encryption = require('../../../lib/common/encryption'),
+  KMS = require('aws-sdk').KMS,
+  sinon = require('sinon');
+
+/*
+  All constants relating to encrypting data. DATA was encrypted into ENCRYPTED_DATA with the key PLAINTEXT_KEY using
+  the ALGORITHM. If any of these constants need to change, the values need to be recomputed. CIPHERTEXT_KEY is not
+  dependent on any of the other settings, and does not need to be recomputed.
+*/
+const
+  ALGORITHM = 'aes-256-ecb',
+  CIPHERTEXT_KEY = 'ciphertext',
+  DATA = {key: 'test key', value: 'test value'},
+  ENCRYPTED_DATA = 'o9w7+YNBLNpmlzIBIL06Gf0bpy7xgn7s3EpCJvh3pPHGaNehTNv111UU9a0Bmvhl',
+  PLAINTEXT_KEY = '00000000001111111111222222222233';
+
+describe('Encryption', () => {
+  let kms;
+
+  before(() => {
+    kms = {
+      generateDataKey: sinon.stub().returns({
+        promise: () => Promise.resolve({Plaintext: PLAINTEXT_KEY, CiphertextBlob: CIPHERTEXT_KEY})
+      }),
+      decrypt: sinon.stub().returns({
+        promise: () => Promise.resolve(PLAINTEXT_KEY)
+      })
+    };
+  });
+
+  describe('encrypt()', () => {
+    let promise;
+
+    before(() => {
+      promise = encryption.encrypt(DATA, ALGORITHM, kms, 'KeyName');
+    });
+
+    it('calls KMS.generateDataKey() with the correct arguments', () => {
+      let argument = { KeyId: 'KeyName', KeySpec: 'AES_256' };
+      return promise.then(payload => {
+        kms.generateDataKey.args[0][0].should.eql(argument);
+      });
+    });
+
+    describe('the return object', () => {
+      it('has the correct properties', () => {
+        return promise.then(payload => {
+          payload.should.have.all.keys(['data', 'key']);
+        });
+      });
+
+      it('has the correct encrypted data', () => {
+        return promise.then(payload => {
+          payload.data.should.eql(ENCRYPTED_DATA);
+        });
+      });
+
+      it('has the key used for encryption', () => {
+        return promise.then(payload => {
+          payload.key.should.eql(CIPHERTEXT_KEY);
+        });
+      });
+    });
+  });
+
+  describe('decrypt()', () => {
+    let payload, promise;
+
+    before(() => {
+      payload = {data: ENCRYPTED_DATA, key: CIPHERTEXT_KEY};
+      promise = encryption.decrypt(payload, ALGORITHM, kms);
+    });
+
+    it('calls KMS.decrypt() with the correct arguments', () => {
+      let argument = {CiphertextBlob: CIPHERTEXT_KEY};
+      return promise.then(payload => {
+        kms.decrypt.args[0][0].should.eql(argument);
+      });
+    });
+
+    it('returns the correct decrypted data', () => {
+      return promise.then(decryptedData => {
+        decryptedData.should.eql(DATA);
+      });
+    });
+  });
+});

--- a/test/unit/fixtures/encryption-fixture.js
+++ b/test/unit/fixtures/encryption-fixture.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const ALGORITHM = 'aes-256-ecb';
+const CIPHERTEXT_KEY = 'ciphertext';
+const DATA = {key: 'test key', value: 'test value'};
+const ENCRYPTED_DATA = 'o9w7+YNBLNpmlzIBIL06Gf0bpy7xgn7s3EpCJvh3pPHGaNehTNv111UU9a0Bmvhl';
+const ENCRYPTED_PAYLOAD = {data: ENCRYPTED_DATA, key: CIPHERTEXT_KEY};
+const PLAINTEXT_KEY = '00000000001111111111222222222233';
+
+module.exports = {
+  ALGORITHM,
+  CIPHERTEXT_KEY,
+  DATA,
+  ENCRYPTED_DATA,
+  ENCRYPTED_PAYLOAD,
+  PLAINTEXT_KEY
+};

--- a/test/unit/fixtures/encryption-fixture.js
+++ b/test/unit/fixtures/encryption-fixture.js
@@ -1,14 +1,17 @@
 'use strict';
 
-const ALGORITHM = 'aes-256-ecb';
+/*
+  All constants relating to encrypting data. DATA was encrypted into ENCRYPTED_DATA with the key PLAINTEXT_KEY.
+  If any of these constants need to change, the values need to be recomputed. CIPHERTEXT_KEY is not
+  dependent on any of the other settings, and does not need to be recomputed.
+*/
 const CIPHERTEXT_KEY = 'ciphertext';
 const DATA = {key: 'test key', value: 'test value'};
-const ENCRYPTED_DATA = 'o9w7+YNBLNpmlzIBIL06Gf0bpy7xgn7s3EpCJvh3pPHGaNehTNv111UU9a0Bmvhl';
+const ENCRYPTED_DATA = 'U2FsdGVkX1+yJ81Mbd23pFIkhXq7tFfHFCB9iAQLAmryztJwqkAHw2+0PdU3VB0v1IUNGfK93tFvJ4ZPcbMnrg==';
 const ENCRYPTED_PAYLOAD = {data: ENCRYPTED_DATA, key: CIPHERTEXT_KEY};
 const PLAINTEXT_KEY = '00000000001111111111222222222233';
 
 module.exports = {
-  ALGORITHM,
   CIPHERTEXT_KEY,
   DATA,
   ENCRYPTED_DATA,

--- a/test/unit/fixtures/encryption-fixture.js
+++ b/test/unit/fixtures/encryption-fixture.js
@@ -5,11 +5,11 @@
   If any of these constants need to change, the values need to be recomputed. CIPHERTEXT_KEY is not
   dependent on any of the other settings, and does not need to be recomputed.
 */
-const CIPHERTEXT_KEY = 'ciphertext';
-const DATA = {key: 'test key', value: 'test value'};
-const ENCRYPTED_DATA = 'U2FsdGVkX1+yJ81Mbd23pFIkhXq7tFfHFCB9iAQLAmryztJwqkAHw2+0PdU3VB0v1IUNGfK93tFvJ4ZPcbMnrg==';
+const CIPHERTEXT_KEY = '0101030078272078a6a49e40b3b49b112d08fd9bbdc92ba31545b984791c3732507b87f4d70000007e307c06092a864886f70d010706a06f306d020100306806092a864886f70d010701301e060960864801650304012e3011040c8bb0ce00520444cdf20c010d020110803b440788a79fc5d852848ac694e203c5f4a97a5502266a35fd5fb4afb88f8ffd450908ad52f425bb6d85091ac68187e3025232e81d7c4c9b7b4cd118';
+const DATA = {someProperty: 'some property value', someOtherProperty: 'some other property value'};
+const ENCRYPTED_DATA = 'U2FsdGVkX18/uu8Konmet8cCMahvUuPstqLyS3figm6O8yOOC79i0shuHyPEGWow+NieTbjPwLmIcZN230HDmC5v/HTPpKiX0sOnS0DHHf5leRP4lGsnJS7D+XgbPTawTsgTPHnnAvfVQgS//cYLhQ==';
 const ENCRYPTED_PAYLOAD = {data: ENCRYPTED_DATA, key: CIPHERTEXT_KEY};
-const PLAINTEXT_KEY = '00000000001111111111222222222233';
+const PLAINTEXT_KEY = '065d40571aa541cce57ddaf484639a14b8ddfd61725d9bfa81fa0bc9b8c1ef5f';
 
 module.exports = {
   CIPHERTEXT_KEY,

--- a/test/unit/sqs/sqs-base-spec.js
+++ b/test/unit/sqs/sqs-base-spec.js
@@ -56,6 +56,8 @@ describe('SqsConsumer', () => {
     sqs.createQueue.resetHistory();
     sqs.getQueueUrl.resetHistory();
     sqs.sendMessage.resetHistory();
+
+    sqsBase._encryption = conf.encryption;
   });
 
   after(() => {
@@ -159,6 +161,16 @@ describe('SqsConsumer', () => {
           QueueUrl: MOCK_QUEUE_URL
         });
       });
+    });
+
+    it('should throw an EncryptionConfigurationError if encryption config is not found', () => {
+      sqsBase._encryption = undefined;
+
+      let msgData = { test: 'test' };
+      let msgToEncrypt = { myKey: 'encrypt this pls' };
+      let encryptedPayload = { encrypted: { data: 'pdIDQFVoW+wVRzAGNPEfl2upzFizbStRhxSXauZPl8c=', key: CIPHERTEXT_BLOB }};
+
+      return sqsBase.sendMessage(msgData, msgToEncrypt).should.rejectedWith(error.EncryptionConfigurationError);
     });
   });
 

--- a/test/unit/sqs/sqs-consumer-spec.js
+++ b/test/unit/sqs/sqs-consumer-spec.js
@@ -18,7 +18,7 @@ const
 const
   encryptFixture = require('../fixtures/encryption-fixture');
 
-describe('SqsConsumer', () => {
+describe.only('SqsConsumer', () => {
   let consumer, sqs, kms, schemaService;
 
   beforeEach(() => {
@@ -41,7 +41,10 @@ describe('SqsConsumer', () => {
     };
     kms = {
       generateDataKey: sinon.stub().returns({
-        promise: () => Promise.resolve({Plaintext: encryptFixture.PLAINTEXT_KEY, CiphertextBlob: encryptFixture.CIPHERTEXT_KEY})
+        promise: () => Promise.resolve({
+          Plaintext: encryptFixture.PLAINTEXT_KEY,
+          CiphertextBlob: encryptFixture.CIPHERTEXT_KEY
+        })
       }),
       decrypt: sinon.stub().returns({
         promise: () => Promise.resolve(encryptFixture.PLAINTEXT_KEY)
@@ -564,7 +567,6 @@ describe('SqsConsumer', () => {
     before(() => {
       conf = {
         encryption: {
-          algorithm: encryptFixture.ALGORITHM,
           key: 'Key Name'
         }
       };


### PR DESCRIPTION
Ticket: [RUI-1379](https://jira.meltdev.com/browse/RUI-1379)

Added the ability to send sensitive data through SQS via encryption. Sensitive data is handed to the SQS `sendMessage()` function, and it will encrypt it, add it to the message body, and send it to the queue. On the consumer side, it will take the message, decrypt it, and send it along like normal. The user should not have to worry about writing encryption code, other than setting up the encryption configuration values.

### Overview
- The original SQS `sendMessage()` function now takes an optional second argument for data that should be encrypted.
- Encrypted data is attached to the original message body as a child object on the `encrypted` key. This child object has a data property, which is the encrypted data, and a key property, which is an encrypted version of the key used to encrypt the data.
- Encryption is done via AWS KMS.
- A new `encryption` property was added to the config to allow customization of the KMS key name to use for encryption. The configuration values must be set for the data to be encrypted and sent along.
  - key: The name of the KMS key to generate a key from, which will be used for the encryption.
- If data is passed without the configuration set, an `EncryptionConfigurationError` is thrown.

```js
// Configuration
{
  awsext: {
    sqs: {
      my-consumer: {
        queue: { ... },
        sqsOptions: { ... },
        kmsOptions: { ... }, // <-- Options to be passed to the KMS instance
        encryption: { // <-- Encryption configuration for sending sensitive data through SQS
          key: 'Key for SQS secure transport' // <-- KMS master key name
        }
      }
    }
  }
}
```
```js
// SQS Message Body with Encrypted Data
{
  myProperty: 'myValue',
  encrypted: {
    data: 'Ab48EF303fbeAcd908tKj2erMnd3',
    key: 'Bc59FG414gcdBde019uLk3dsNoe4'
  }
}
```