### PR TITLE
Retry Updates

### DIFF
--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -11,15 +11,17 @@ const
  */
 class Retrier {
 
-  constructor(minWaitSeconds, maxWaitSeconds) {
+  constructor(minWaitSeconds, maxWaitSeconds, maxRetries, exponentBase) {
     this.minWaitSeconds = minWaitSeconds || 60;
     this.maxWaitSeconds = maxWaitSeconds || 60*10;
+    this.maxRetries = maxRetries || 10;
+    this.exponentBase = exponentBase || 2;
   }
 
   nextTryInterval(tries) {
     return Math.min(
       this.maxWaitSeconds,
-      this.minWaitSeconds +  (2 << Math.min(tries-1, 29)));
+      this.minWaitSeconds * Math.pow(this.exponentBase, Math.min(tries, this.maxRetries)));
   }
 }
 

--- a/lib/sqs/sqs-consumer.js
+++ b/lib/sqs/sqs-consumer.js
@@ -168,8 +168,11 @@ class SqsConsumer extends SqsBase {
           return true;
         });
     }
-    winston.error(`SqsConsumer::${this.name}:: An error occurred processing message: ${message.MessageId}`,
-      err);
+    //Only throw errors if we've retried more than the maxRetry count
+    if (message.Attributes.ApproximateReceiveCount >= this.conf.message.error.maxRetries) {
+      winston.error(`SqsConsumer::${this.name}:: An error occurred processing message: ${message.MessageId}`,
+        err);
+    }
     throw err;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-sdk-ext",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "AWS SDK Javascript Extensions",
   "main": "lib/index.js",
   "scripts": {

--- a/test/unit/common/utils-spec.js
+++ b/test/unit/common/utils-spec.js
@@ -11,7 +11,7 @@ describe('utils', () => {
   describe('nextRetryInterval', () => {
 
     it('should calculate next retry interval', () => {
-      commonUtils.nextRetryInterval(3).should.be.equal(68);
+      commonUtils.nextRetryInterval(3).should.be.equal(480);
     });
 
     it('should limit max interval', () => {

--- a/test/unit/sqs/sqs-consumer-spec.js
+++ b/test/unit/sqs/sqs-consumer-spec.js
@@ -14,8 +14,8 @@ const
 const
   MOCK_QUEUE_URL = 'http://MockQueueUrl',
   MOCK_MESSAGE_WITH_ID = {MessageId: 'MOCK-MESSAGE-ID'},
-  EXPECTED_MESSAGE_VISIBILITY = 62, //seconds
-  EXPECTED_POLL_WAIT = 12000; //ms
+  EXPECTED_MESSAGE_VISIBILITY = 120, //seconds
+  EXPECTED_POLL_WAIT = 20000; //ms
 
 const
   encryptFixture = require('../fixtures/encryption-fixture');


### PR DESCRIPTION
https://jira.meltdev.com/browse/RUI-1871
https://jira.meltdev.com/browse/RUI-1913

Retrier can now use expontential back off determined by the minWaitTime instead of just adding 2,4,8... seconds every time.

Additionally, there is now a "maxRetries" value, it doesn't actually stop the retries (so maybe it should be renamed), which when a retrier exceeds that number of retries will _then_ begin throwing error messages instead.