### PR TITLE
Updates max retry interval

### DIFF
--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -13,7 +13,7 @@ class Retrier {
 
   constructor(minWaitSeconds, maxWaitSeconds, maxRetries, exponentBase) {
     this.minWaitSeconds = minWaitSeconds || 60;
-    this.maxWaitSeconds = maxWaitSeconds || 60*10;
+    this.maxWaitSeconds = maxWaitSeconds || 60*30;
     this.maxRetries = maxRetries || 10;
     this.exponentBase = exponentBase || 2;
   }

--- a/lib/sqs/sqs-consumer.js
+++ b/lib/sqs/sqs-consumer.js
@@ -28,7 +28,7 @@ const DEFAULT_AWS_EXT_CONFIG = {
       message: {
         error: {
           minVisibility: 60, // seconds
-          maxVisibility : 600, //seconds
+          maxVisibility : 1800, //seconds
           maxRetries: 10,
           exponentBase: 2
         }

--- a/test/unit/common/utils-spec.js
+++ b/test/unit/common/utils-spec.js
@@ -15,7 +15,7 @@ describe('utils', () => {
     });
 
     it('should limit max interval', () => {
-      commonUtils.nextRetryInterval(10).should.be.equal(600);
+      commonUtils.nextRetryInterval(10).should.be.equal(1800);
     });
 
   });


### PR DESCRIPTION
https://jira.meltdev.com/browse/RUI-1913

Increases default max retry interval to 30 minutes instead of 10 minutes

Expected defaults:

1. 2 minutes (120 seconds)
2. 4 minutes (240 seconds)
3. 8 minutes (480 seconds)
4. 16 minutes (960 seconds)
5. 30 minutes (1800 seconds) _new max_
6. 30 minutes (1800 seconds)
...

